### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.7
+    rev: v0.4.8
     hooks:
       # Run the linter.s
       - id: ruff


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the pre-commit hook for the Ruff linter to a newer version (v0.4.8) in the configuration file.

* **Chores**:
    - Updated the pre-commit hook for the Ruff linter to version v0.4.8 in the .pre-commit-config.yaml file.

<!-- Generated by sourcery-ai[bot]: end summary -->