### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.8
+    rev: v0.4.9
     hooks:
       # Run the linter.s
       - id: ruff


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the pre-commit configuration to use the latest version of the Ruff linter.

* **Chores**:
    - Updated the pre-commit hook for the Ruff linter from version v0.4.8 to v0.4.9.

<!-- Generated by sourcery-ai[bot]: end summary -->