### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
       # Run the linter
       - id: ruff
@@ -43,7 +43,7 @@ repos:
         args: ['--exclude-files', '.*[^i][^p][^y][^n][^b]$', '--exclude-lines', '"(hash|id|image/\w+)":.*', ]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.6.1
+    rev: v4.7.0
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Build:
- Update ruff-pre-commit hook to v0.11.9 and commitizen hook to v4.7.0 in pre-commit configuration.