### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.10
+    rev: v0.11.11
     hooks:
       # Run the linter
       - id: ruff
@@ -34,7 +34,7 @@ repos:
           - --config-file=.code_quality/mypy.ini
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.7.2
+    rev: v4.8.2
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Apply automated updates to pre-commit hook versions

Chores:
- Bump ruff pre-commit hook from v0.11.10 to v0.11.11
- Bump commitizen hooks from v4.7.2 to v4.8.2