### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.5
+    rev: v0.12.7
     hooks:
       # Run the linter
       - id: ruff
@@ -27,7 +27,7 @@ repos:
           - .code_quality/ruff.toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.0
+    rev: v1.17.1
     hooks:
       - id: mypy
         args:


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update pre-commit hooks for ruff and mypy to their latest patch versions

CI:
- Bump ruff hook from v0.12.5 to v0.12.7
- Bump mypy hook from v1.17.0 to v1.17.1