### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.8
+    rev: v0.12.9
     hooks:
       # Run the linter
       - id: ruff


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Chores:
- Bump ruff-pre-commit hook from v0.12.8 to v0.12.9