### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.12
+    rev: v0.13.0
     hooks:
       # Run the linter
       - id: ruff
@@ -27,14 +27,14 @@ repos:
           - .code_quality/ruff.toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+    rev: v1.18.1
     hooks:
       - id: mypy
         args:
           - --config-file=.code_quality/mypy.ini
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.8.4
+    rev: v4.9.0
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update pre-commit configuration to use the latest versions of hooks

Build:
- Bump ruff-pre-commit hook from v0.12.12 to v0.13.0
- Bump mypy hook from v1.17.1 to v1.18.1
- Bump commitizen hooks from v4.8.4 to v4.9.0