### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.17
+    rev: v0.15.18
     hooks:
       # Run the linter
       - id: ruff
@@ -34,7 +34,7 @@ repos:
           - --config-file=.code_quality/mypy.ini
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.3
+    rev: v4.16.4
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update pre-commit hook versions for linting and commit tooling.

Build:
- Bump ruff-pre-commit hook from v0.15.17 to v0.15.18 in .pre-commit-config.yaml.
- Bump commitizen pre-commit hook from v4.16.3 to v4.16.4 in .pre-commit-config.yaml.