### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.20
+    rev: v0.15.21
     hooks:
       # Run the linter
       - id: ruff
@@ -27,7 +27,7 @@ repos:
           - .code_quality/ruff.toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.2.0
     hooks:
       - id: mypy
         args:


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update code quality tooling versions in pre-commit configuration.

Build:
- Bump ruff-pre-commit hook to v0.15.21 in .pre-commit-config.yaml.
- Bump mypy mirror hook to v2.2.0 in .pre-commit-config.yaml.

Chores:
- Refresh pre-commit hook revisions to align with latest tool releases.