### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.21
+    rev: v0.15.22
     hooks:
       # Run the linter
       - id: ruff
@@ -27,14 +27,14 @@ repos:
           - .code_quality/ruff.toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.2.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         args:
           - --config-file=.code_quality/mypy.ini
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.4
+    rev: v4.16.5
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update code quality tooling versions in pre-commit configuration.

Build:
- Bump Ruff pre-commit hook from v0.15.21 to v0.15.22.
- Bump mypy pre-commit hook from v2.2.0 to v2.3.0.
- Bump Commitizen pre-commit hook from v4.16.4 to v4.16.5.