### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.16.0
+    rev: v0.16.1
     hooks:
       # Run the linter
       - id: ruff
@@ -34,7 +34,7 @@ repos:
           - --config-file=.code_quality/mypy.ini
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.5
+    rev: v4.17.0
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update pre-commit hook versions for linting and commit message tooling.

Build:
- Bump ruff-pre-commit hook to v0.16.1 in the pre-commit configuration.
- Bump commitizen pre-commit hook to v4.17.0 in the pre-commit configuration.